### PR TITLE
restaurant 도메인 수정

### DIFF
--- a/src/main/java/com/rodemtree/yeyakitda/entity/RestaurantEntity.java
+++ b/src/main/java/com/rodemtree/yeyakitda/entity/RestaurantEntity.java
@@ -22,9 +22,6 @@ public class RestaurantEntity extends BaseEntity {
     @Column(name = "name", length = 32, nullable = false)
     private String name;
 
-    @Column(name = "thumbnail_image_url", length = 256)
-    private String thumbnailImageUrl;
-
     @ManyToOne
     @JoinColumn(name = "thumbnail_image_id")
     private RestaurantImageEntity restaurantImage;
@@ -59,5 +56,9 @@ public class RestaurantEntity extends BaseEntity {
         this.phoneNumber = phoneNumber;
         this.address = address;
         this.category = category;
+    }
+
+    public void updateRestaurantThumbnailImage(RestaurantImageEntity restaurantImage) {
+        this.restaurantImage = restaurantImage;
     }
 }

--- a/src/main/java/com/rodemtree/yeyakitda/entity/RestaurantImageEntity.java
+++ b/src/main/java/com/rodemtree/yeyakitda/entity/RestaurantImageEntity.java
@@ -1,6 +1,7 @@
 package com.rodemtree.yeyakitda.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,4 +20,13 @@ public class RestaurantImageEntity extends BaseEntity {
 
     @Column(name = "image_url", length = 256, nullable = false)
     private String imageUrl;
+
+    private RestaurantImageEntity(RestaurantEntity restaurant, String imageUrl) {
+        this.restaurant = restaurant;
+        this.imageUrl = imageUrl;
+    }
+
+    public static RestaurantImageEntity of(RestaurantEntity restaurant, String imageUrl) {
+        return new RestaurantImageEntity(restaurant, imageUrl);
+    }
 }

--- a/src/main/java/com/rodemtree/yeyakitda/mapper/RestuarantMapper.java
+++ b/src/main/java/com/rodemtree/yeyakitda/mapper/RestuarantMapper.java
@@ -3,9 +3,12 @@ package com.rodemtree.yeyakitda.mapper;
 import com.rodemtree.yeyakitda.dto.RestaurantDto;
 import com.rodemtree.yeyakitda.entity.RestaurantEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface RestuarantMapper {
 
+    @Mapping(source = "restaurantImage.imageUrl", target = "thumbnailImageUrl")
     RestaurantDto restaurantEntityToRestaurantDto(RestaurantEntity entity);
+
 }

--- a/src/test/java/com/rodemtree/yeyakitda/mapper/RestuarantMapperTest.java
+++ b/src/test/java/com/rodemtree/yeyakitda/mapper/RestuarantMapperTest.java
@@ -1,0 +1,44 @@
+package com.rodemtree.yeyakitda.mapper;
+
+import com.rodemtree.yeyakitda.dto.RestaurantDto;
+import com.rodemtree.yeyakitda.entity.RestaurantEntity;
+import com.rodemtree.yeyakitda.entity.RestaurantImageEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@ExtendWith(MockitoExtension.class)
+class RestuarantMapperTest {
+
+    private RestuarantMapper restuarantMapper = Mappers.getMapper(RestuarantMapper.class);
+
+    @Test
+    @DisplayName("성공 - restaurantEntity -> restaurantDto 변환")
+    void restaurantEntityToRestaurantDtoTest() {
+        // Given
+        RestaurantEntity restaurantEntity = RestaurantEntity.builder()
+                .name("테스트 식당")
+                .category("한식")
+                .description("테스트 식당 상세 내용")
+                .address("경기도 구리시")
+                .build();
+        RestaurantImageEntity restaurantImageEntity = RestaurantImageEntity.of(restaurantEntity, "https://test.com/image.png");
+        restaurantEntity.updateRestaurantThumbnailImage(restaurantImageEntity);
+
+        // When
+        RestaurantDto restaurantDto = restuarantMapper.restaurantEntityToRestaurantDto(restaurantEntity);
+
+        // Then
+        assertThat(restaurantDto.name()).isEqualTo(restaurantEntity.getName());
+        assertThat(restaurantDto.thumbnailImageUrl()).isEqualTo(restaurantEntity.getRestaurantImage().getImageUrl());
+        assertThat(restaurantDto.description()).isEqualTo(restaurantEntity.getDescription());
+        assertThat(restaurantDto.address()).isEqualTo(restaurantEntity.getAddress());
+        assertThat(restaurantDto.category()).contains(restaurantEntity.getCategory());
+        assertThat(restaurantDto.rating()).isEqualTo(restaurantEntity.getRating());
+    }
+}


### PR DESCRIPTION
처음에는 restaurant 테이블에 thumbnail_image_id와 thumbnail_image_url 필드를 설계했다.
그 이유는 restaurant_image 테이블에 썸네일인지 표시하는 필드를 넣을까 했는데
한 식당의 사진중 하나만 썸네일이고 나머지는 null이거나 false이면 공간 낭비일거라 생각했다.
그래서 Restaurant 테이블에 thumbnail_image_id 필드를 추가해 join으로 url을 가져올 샐각을 했다.
이것도 혹시 요청이 많아지면 join 쿼리가 부담스럽지 않을까 생각해 thumbnail_image_url 필드를 추가해 캐시 목적으로 설계했다.

join 쿼리의 부담 vs 캐시 유지에 필요한 코드 복잡성과 동기화 문제를 고민하다가
join 쿼리가 그렇게 까지 부담스럽지 않을거 같아서 thumbnail_image_id만 유지하기로했다.

성능문제가 되면 그때 바꾸기로